### PR TITLE
Optional syntactic equivalence & Boolean algebra for evaluation

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: Pytest
+          name: Pytest Report
           artifact: test-results
           path: '*.xml'
           reporter: java-junit

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -9,7 +9,12 @@ try:
 except:
     from parse import parse_with_feedback, FeedbackException
 
-def evaluation_function(response: Any, answer: Any, params: Params, include_test_data: bool = False) -> dict:
+def evaluation_function(
+    response: Any,
+    answer: Any,
+    params: Params,
+    include_test_data: bool = False,
+) -> dict:
     """
     Function used to evaluate a student response.
     ---
@@ -49,12 +54,27 @@ def evaluation_function(response: Any, answer: Any, params: Params, include_test
         answerSet = parser.parse(answer, latex=False)
         answerSetSympy = sympyTransformer.transform(answerSet)
 
-        # 3. TODO: compare the two sympy expressions w/ simplification enabled. If they are equal, the sets produced by the two expressions are equal. However, the expressions may not be equal.
-        # 4. compare the two sympy expressions w/ simplifaction disabled. If they are equal, the expressions are also equal.
-        # 5a. TODO: If `params.enforce_expression_equality` is True, `is_correct` is True iff both 3) and 4) are True.
-        # 5b. If `params.enforce_expression_equality` is False, `is_correct` is True iff 3) is True.
-        result = simplify_logic(Equivalent(responseSetSympy, answerSetSympy))
-        is_correct = result == True
+        # 3. compare the two sympy expressions w/ simplification enabled.
+        #    If they are equal, the sets produced by the two expressions are
+        #    semantically equal. However, the expressions may not be equal.
+        semantic_equal = simplify_logic(Equivalent(responseSetSympy, answerSetSympy)) == True
+
+        # 4. compare the two sympy expressions w/ simplifaction disabled.
+        #    If they are equal, the expressions are also equal in syntax.
+        #    This respects laws of commutativity, e.g. A u B == B u A.
+        syntactic_equal = responseSetSympy == answerSetSympy
+
+        enforce_expression_equality = params.get("enforce_expression_equality", False)
+
+        # 5. `is_correct` is True, iff 3) is True, and either 4) or `enforce_expression_equality` is True
+        is_correct = semantic_equal and (syntactic_equal or not enforce_expression_equality)
+
+        feedback_items=[]
+
+        if semantic_equal and not syntactic_equal:
+            feedback_items.append(("syntactic_equality", "The expressions are not equal syntacitcally."))
+        if not semantic_equal:
+            feedback_items.append(("semantic_equality", "The expressions are not equal."))
 
         latexPrinter = LatexPrinter()
         latex = latexPrinter.print(responseSet)

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -1,7 +1,7 @@
 from typing import Any
-from sympy import simplify, EmptySet
+from sympy import simplify_logic, Equivalent
 from lf_toolkit.evaluation import Result, Params
-from lf_toolkit.parse.set import SetParser, LatexPrinter, SymPyTransformer, ASCIIPrinter
+from lf_toolkit.parse.set import SetParser, LatexPrinter, SymPyBooleanTransformer, ASCIIPrinter
 
 # TODO: this is hacky, we need another way to bundle up everything.
 try:
@@ -34,7 +34,7 @@ def evaluation_function(response: Any, answer: Any, params: Params, include_test
     """
 
     parser = SetParser.instance()
-    sympyTransformer = SymPyTransformer()
+    sympyTransformer = SymPyBooleanTransformer()
 
     # here we want to compare the response set with the example solution set.
     # we have to do the following steps
@@ -53,8 +53,8 @@ def evaluation_function(response: Any, answer: Any, params: Params, include_test
         # 4. compare the two sympy expressions w/ simplifaction disabled. If they are equal, the expressions are also equal.
         # 5a. TODO: If `params.enforce_expression_equality` is True, `is_correct` is True iff both 3) and 4) are True.
         # 5b. If `params.enforce_expression_equality` is False, `is_correct` is True iff 3) is True.
-        difference = simplify(answerSetSympy - responseSetSympy)
-        is_correct = difference == EmptySet
+        result = simplify_logic(Equivalent(responseSetSympy, answerSetSympy))
+        is_correct = result == True
 
         latexPrinter = LatexPrinter()
         latex = latexPrinter.print(responseSet)

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -71,9 +71,9 @@ def evaluation_function(
 
         feedback_items=[]
 
-        if semantic_equal and not syntactic_equal:
+        if semantic_equal and not syntactic_equal and enforce_expression_equality:
             feedback_items.append(("syntactic_equality", "The expressions are not equal syntacitcally."))
-        if not semantic_equal:
+        elif not semantic_equal:
             feedback_items.append(("semantic_equality", "The expressions are not equal."))
 
         latexPrinter = LatexPrinter()
@@ -86,6 +86,7 @@ def evaluation_function(
             is_correct=is_correct,
             latex=latex,
             simplified=ascii,
+            feedback_items=feedback_items,
         ).to_dict(include_test_data=include_test_data)
     except FeedbackException as e:
         return Result(

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -32,6 +32,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "A \\cap B")
+        self.assertFalse(result.get("feedback"))
 
     def test_intersection_is_commutative(self):
         """
@@ -44,6 +45,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "A \\cap B")
+        self.assertFalse(result.get("feedback"))
 
     def test_union_of_complement(self):
         """
@@ -56,6 +58,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "\\overline{B} \\cup B")
+        self.assertFalse(result.get("feedback"))
 
     def test_de_morgan(self):
         """
@@ -72,6 +75,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "\\overline{\\left(A \\cap B\\right)}")
+        self.assertFalse(result.get("feedback"))
 
     def test_intersection_of_complement(self):
         response, answer, params = "B' n B", "A n A'", Params()
@@ -80,6 +84,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "\\overline{B} \\cap B")
+        self.assertFalse(result.get("feedback"))
 
     def test_returns_is_correct_true_latex(self):
         response, answer, params = "A \\cap B", "A n B", Params(is_latex=True)
@@ -88,6 +93,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "A \\cap B")
+        self.assertFalse(result.get("feedback"))
 
     def test_returns_is_correct_false(self):
         response, answer, params = "A n B", "A u B", Params()
@@ -96,6 +102,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), False)
         self.assertEqual(result.get("response_latex"), "A \\cap B")
+        self.assertTrue(result.get("feedback"))
 
     def test_returns_is_correct_false_not_parseable(self):
         response, answer, params = "", "A u B", Params()
@@ -104,6 +111,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), False)
         self.assertEqual(result.get("response_latex"), None)
+        self.assertTrue(result.get("feedback"))
 
     def test_syntactic_returns_is_correct_true_commutativity(self):
         response, answer, params = "A u B", "B u A", Params(enforce_expression_equality=True)
@@ -112,6 +120,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "A \\cup B")
+        self.assertFalse(result.get("feedback"))
 
     def test_syntactic_returns_is_correct_false_de_morgan(self):
         response, answer, params = "(A u B)'", "A' n B'", Params(enforce_expression_equality=True)
@@ -120,6 +129,7 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), False)
         self.assertEqual(result.get("response_latex"), "\\overline{\\left(A \\cup B\\right)}")
+        self.assertTrue(result.get("feedback"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -55,7 +55,7 @@ class TestEvaluationFunction(unittest.TestCase):
         result = evaluation_function(response, answer, params)
 
         self.assertEqual(result.get("is_correct"), True)
-        self.assertEqual(result.get("response_latex"), "\overline{B} \\cup B")
+        self.assertEqual(result.get("response_latex"), "\\overline{B} \\cup B")
 
     def test_de_Morgan(self):
         """
@@ -65,13 +65,13 @@ class TestEvaluationFunction(unittest.TestCase):
         result = evaluation_function(response, answer, params)
 
         self.assertEqual(result.get("is_correct"), True)
-        self.assertEqual(result.get("response_latex"), "\overline{\\left(A \\cup B\\right)}")
+        self.assertEqual(result.get("response_latex"), "\\overline{\\left(A \\cup B\\right)}")
 
         response, answer, params = "(A n B)'", "A' u B'", Params()
         result = evaluation_function(response, answer, params)
 
         self.assertEqual(result.get("is_correct"), True)
-        self.assertEqual(result.get("response_latex"), "\overline{\left(A \\cap B\\right)}")
+        self.assertEqual(result.get("response_latex"), "\\overline{\left(A \\cap B\\right)}")
 
     def test_intersection_of_complement(self):
         response, answer, params = "B' n B", "A n A'", Params()
@@ -79,7 +79,7 @@ class TestEvaluationFunction(unittest.TestCase):
         result = evaluation_function(response, answer, params)
 
         self.assertEqual(result.get("is_correct"), True)
-        self.assertEqual(result.get("response_latex"), "\overline{B} \\cap B")
+        self.assertEqual(result.get("response_latex"), "\\overline{B} \\cap B")
 
     def test_returns_is_correct_true_latex(self):
         response, answer, params = "A \\cap B", "A n B", Params(is_latex=True)

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -57,7 +57,7 @@ class TestEvaluationFunction(unittest.TestCase):
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "\\overline{B} \\cup B")
 
-    def test_de_Morgan(self):
+    def test_de_morgan(self):
         """
         Testing de Morgan's well known laws
         """
@@ -104,6 +104,22 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(result.get("is_correct"), False)
         self.assertEqual(result.get("response_latex"), None)
+
+    def test_syntactic_returns_is_correct_true_commutativity(self):
+        response, answer, params = "A u B", "B u A", Params(enforce_expression_equality=True)
+
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "A \\cup B")
+
+    def test_syntactic_returns_is_correct_false_de_morgan(self):
+        response, answer, params = "(A u B)'", "A' n B'", Params(enforce_expression_equality=True)
+
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), False)
+        self.assertEqual(result.get("response_latex"), "\\overline{\\left(A \\cup B\\right)}")
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -33,6 +33,54 @@ class TestEvaluationFunction(unittest.TestCase):
         self.assertEqual(result.get("is_correct"), True)
         self.assertEqual(result.get("response_latex"), "A \\cap B")
 
+    def test_intersection_is_commutative(self):
+        """
+        Since A n A' is equal to the empty set (by definition of complement)
+        for any set A, then B' u B should be considered equal to A n A'
+        """
+        response, answer, params = "A n B", "B n A", Params()
+
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "A \\cap B")
+
+    def test_union_of_complement(self):
+        """
+        Since A u A' is equal to the Universal set (by definition of complement)
+        for any set A, then B' u B should be considered equal to A u A'
+        """
+        response, answer, params = "B' u B", "A u A'", Params()
+
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "\overline{B} \\cup B")
+
+    def test_de_Morgan(self):
+        """
+        Testing de Morgan's well known laws
+        """
+        response, answer, params = "(A u B)'", "A' n B'", Params()
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "\overline{\\left(A \\cup B\\right)}")
+
+        response, answer, params = "(A n B)'", "A' u B'", Params()
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "\overline{\left(A \\cap B\\right)}")
+
+    def test_intersection_of_complement(self):
+        response, answer, params = "B' n B", "A n A'", Params()
+
+        result = evaluation_function(response, answer, params)
+
+        self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("response_latex"), "\overline{B} \\cap B")
+
     def test_returns_is_correct_true_latex(self):
         response, answer, params = "A \\cap B", "A n B", Params(is_latex=True)
 

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -71,7 +71,7 @@ class TestEvaluationFunction(unittest.TestCase):
         result = evaluation_function(response, answer, params)
 
         self.assertEqual(result.get("is_correct"), True)
-        self.assertEqual(result.get("response_latex"), "\\overline{\left(A \\cap B\\right)}")
+        self.assertEqual(result.get("response_latex"), "\\overline{\\left(A \\cap B\\right)}")
 
     def test_intersection_of_complement(self):
         response, answer, params = "B' n B", "A n A'", Params()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,3 @@
 typing_extensions
 pytest
-git+https://github.com/lambda-feedback/toolkit-python.git@d14379fcd9d4331f5212c8d991e606b5be8c9e49#egg=lf_toolkit
+git+https://github.com/lambda-feedback/toolkit-python.git@4fc955c09440887de25f7db813529db7c2ec679f#egg=lf_toolkit


### PR DESCRIPTION
This PR switches to using boolean algebra for evaluation instead of using sets. Using SymPy's sets was problematic, as it is meant to be used with well-defined sets. We might have that at a later stage, but right now the evaluation function is not configurable.

* a new `SymPyBooleanTransformer` [was introduced](https://github.com/lambda-feedback/toolkit-python/commit/4fc955c09440887de25f7db813529db7c2ec679f) in the python toolkit
* the `SymPyBooleanTransformer` is now used to create a boolean expression
* the evaluation is now done by `simplify(Equivalent(response, answer)) == True`

All of the extended tests are now successful. However, this would only check semantic equivalence. Therefore, an optional parameter named `enforce_expression_equality` was introduced, with a default value of `False`. If it is false, only semantic equivalence is checked. Otherwise, syntactic equivalence is also enforced.

Syntactic equivalence has some degree of freedom, however, as it respects commutativity, eg. `A u B == B u A`.

The effective evaluation rule is now `semantic_equal and (syntactic_equal or not enforce_expression_equality)`

~However, we might not want it this way, as the task could be to simplify a boolean expression. If a student now enters the expression in the question, SymPy will do the task of simplification, and the evaluation will be successful. What we want instead is some symbolic equivalence (with some degree of freedom, like `(A u B == B u A)`, with a feedback hint that while the solution produces the same truth table, it's not what the educator wants.~
